### PR TITLE
Adding run in options

### DIFF
--- a/packages/cargo/src/common/index.ts
+++ b/packages/cargo/src/common/index.ts
@@ -139,7 +139,7 @@ export function parseCargoArgs(opts: CargoOptions, ctx: ExecutorContext): string
 	switch (ctx.targetName) {
 		case "build": args.push("build"); break;
 		case "test":  args.push("test");  break;
-
+		case "run": args.push("run"); break;
 		default: {
 			if (ctx.targetName == null) {
 				throw new Error("Expected target name to be non-null");

--- a/packages/cargo/src/generators/binary/generator.ts
+++ b/packages/cargo/src/generators/binary/generator.ts
@@ -32,6 +32,13 @@ export default async function (host: Tree, opts: CLIOptions) {
 					},
 				},
 			},
+			run: {
+				executor: "@nxrs/cargo:build",
+				options: {
+					release: false,
+					run: true
+				},
+			},
 			test: {
 				executor: "@nxrs/cargo:test",
 				options: {},


### PR DESCRIPTION
Adding a "run" option for the executor so that people can just "yarn nx run app:run" for a faster development cycle. 