### PR TITLE
fix: ENOBUFS error in large projects

### DIFF
--- a/packages/cargo/src/graph/index.ts
+++ b/packages/cargo/src/graph/index.ts
@@ -13,7 +13,7 @@ export function processProjectGraph(
 ): ProjectGraph {
 	let metadata = cp.execSync("cargo metadata --format-version=1", {
 		encoding: "utf8",
-		maxBuffer: 1208 * 1208 * 1208 * 16,
+		maxBuffer: 1024 * 1024 * 1024 * 32,
 	});
 	let { packages, workspace_members } = JSON.parse(metadata);
 	let builder = new ProjectGraphBuilder(graph);

--- a/packages/cargo/src/graph/index.ts
+++ b/packages/cargo/src/graph/index.ts
@@ -13,6 +13,7 @@ export function processProjectGraph(
 ): ProjectGraph {
 	let metadata = cp.execSync("cargo metadata --format-version=1", {
 		encoding: "utf8",
+		maxBuffer: 2 << 30,
 	});
 	let { packages, workspace_members } = JSON.parse(metadata);
 	let builder = new ProjectGraphBuilder(graph);

--- a/packages/cargo/src/graph/index.ts
+++ b/packages/cargo/src/graph/index.ts
@@ -13,7 +13,7 @@ export function processProjectGraph(
 ): ProjectGraph {
 	let metadata = cp.execSync("cargo metadata --format-version=1", {
 		encoding: "utf8",
-		maxBuffer: 2 << 30,
+		maxBuffer: 1208 * 1208 * 1208 * 16,
 	});
 	let { packages, workspace_members } = JSON.parse(metadata);
 	let builder = new ProjectGraphBuilder(graph);


### PR DESCRIPTION
I am using nxrs/cargo in a large project the `cargo metadata` command can be many kibibytes large, so i increased the max-buffer size for the command