### PR TITLE
Add support for "package" argument

### DIFF
--- a/packages/cargo/src/common/index.spec.ts
+++ b/packages/cargo/src/common/index.spec.ts
@@ -17,6 +17,25 @@ describe("common utils", () => {
 			);
 		});
 
+		it("should support --package argument", () => {
+			let ctx = mockExecutorContext("test-app:build");
+			let opts: CargoOptions = {
+				package: "foo",
+			};
+
+			let args = ["cargo", ...parseCargoArgs(Target.Build, opts, ctx)];
+			expect(args.join(" ")).toEqual("cargo build --bin foo");
+
+			args = ["cargo", ...parseCargoArgs(Target.Test, opts, ctx)];
+			expect(args.join(" ")).toEqual("cargo test -p foo");
+
+			args = ["cargo", ...parseCargoArgs(Target.Run, opts, ctx)];
+			expect(args.join(" ")).toEqual("cargo run -p foo");
+
+			args = ["cargo", ...parseCargoArgs(Target.Clippy, opts, ctx)];
+			expect(args.join(" ")).toEqual("cargo clippy -p foo");
+		});
+
 		it("should ignore the Nx-config-specified target name", () => {
 			let ctx = mockExecutorContext("test-app:flooptydoopty");
 			let opts: CargoOptions = {};

--- a/packages/cargo/src/executors/build/schema.d.ts
+++ b/packages/cargo/src/executors/build/schema.d.ts
@@ -13,6 +13,7 @@ type Options =
 	& OutputOptions
 	& DisplayOptions
 	& ManifestOptions
+	& { [key: string]: unknown }
 & {
 	/**
 	 * Copy final artifacts to this directory.

--- a/packages/cargo/src/executors/clippy/executor.ts
+++ b/packages/cargo/src/executors/clippy/executor.ts
@@ -1,10 +1,13 @@
 import { ExecutorContext } from "@nrwl/devkit";
-import { runCargo } from "../../common";
+import { parseCargoArgs, runCargo, Target } from "../../common";
 import CLIOptions from "./schema";
 
 export default async function (opts: CLIOptions, ctx: ExecutorContext) {
 	try {
-		let args = parseArgs(opts, ctx);
+		let args = [
+			...parseCargoArgs(Target.Clippy, opts, ctx),
+			...parseClippyArgs(opts),
+		];
 		await runCargo(args, ctx);
 
 		return { success: true };
@@ -16,14 +19,8 @@ export default async function (opts: CLIOptions, ctx: ExecutorContext) {
 	}
 }
 
-function parseArgs(opts: CLIOptions, ctx: ExecutorContext): string[] {
-	let args = ["clippy"];
-
-	if (!ctx.projectName) {
-		throw new Error("Expected project name to be non-null");
-	}
-	args.push("-p", ctx.projectName);
-	args.push("--");
+function parseClippyArgs(opts: CLIOptions): string[] {
+	let args = ["--"];
 
 	if (opts.failOnWarnings || opts.failOnWarnings == null) {
 		args.push("-D", "warnings");
@@ -31,8 +28,9 @@ function parseArgs(opts: CLIOptions, ctx: ExecutorContext): string[] {
 	if (opts.noDeps || opts.noDeps == null) {
 		args.push("--no-deps");
 	}
-
-	if (opts.fix) args.push("--fix");
+	if (opts.fix) {
+		args.push("--fix");
+	}
 
 	return args;
 }

--- a/packages/cargo/src/executors/clippy/schema.d.ts
+++ b/packages/cargo/src/executors/clippy/schema.d.ts
@@ -1,4 +1,15 @@
-export default interface Options {
+import {
+	CompilationOptions,
+	FeatureSelection,
+} from "../../common/schema";
+
+type Options =
+	& FeatureSelection
+	& CompilationOptions
+	& DisplayOptions
+	& ManifestOptions
+	& { [key: string]: unknown }
+& {
 	/** Automatically fix code where possible. */
 	fix?: boolean;
 	/**
@@ -12,4 +23,6 @@ export default interface Options {
 	 * @default true
 	 */
 	noDeps?: boolean;
-}
+};
+
+export default Options;

--- a/packages/cargo/src/executors/run/schema.d.ts
+++ b/packages/cargo/src/executors/run/schema.d.ts
@@ -13,6 +13,7 @@ type Options =
 	& OutputOptions
 	& DisplayOptions
 	& ManifestOptions
+	& { [key: string]: unknown }
 & {
 	/**
 	 * Copy final artifacts to this directory.

--- a/packages/cargo/src/executors/test/schema.d.ts
+++ b/packages/cargo/src/executors/test/schema.d.ts
@@ -12,6 +12,7 @@ type Options =
 	& CompilationOptions
 	& OutputOptions
 	& DisplayOptions
-	& ManifestOptions;
+	& ManifestOptions
+	& { [key: string]: unknown };
 
 export default Options;

--- a/packages/cargo/src/graph/index.ts
+++ b/packages/cargo/src/graph/index.ts
@@ -32,19 +32,19 @@ export function processProjectGraph(
 	let builder = new ProjectGraphBuilder(graph);
 
 	workspace_members
-		.map(id => packages.find(pkg => pkg?.id === id))
-		.filter(pkg => Object.keys(ctx.fileMap).includes(pkg?.name as string))
+		.map(id => packages.find(pkg => pkg?.["id"] === id))
+		.filter(pkg => Object.keys(ctx.fileMap).includes(pkg?.["name"] as string))
 		.forEach(pkg => {
 			if (!pkg) return;
 
-			(pkg.dependencies as JsonObject[])?.forEach(dep => {
-				let depName = dep.source == null
-					? dep.name as string
-					: `cargo:${dep.name}`;
+			(pkg["dependencies"] as JsonObject[])?.forEach(dep => {
+				let depName = dep["source"] == null
+					? dep["name"] as string
+					: `cargo:${dep["name"]}`;
 
 				if (!Object.keys(graph.nodes).includes(depName)) {
 					let depPkg = packages.find(pkg =>
-						(pkg.source as string)?.startsWith(dep.source as string)
+						(pkg["source"] as string)?.startsWith(dep["source"] as string)
 					);
 
 					if (!depPkg) {
@@ -62,14 +62,14 @@ export function processProjectGraph(
 						name: depName,
 						type: "cargo" as any,
 						data: {
-							version: depPkg.version,
-							packageName: depPkg.name,
+							version: depPkg["version"],
+							packageName: depPkg["name"],
 							files: [],
 						},
 					});
 				}
 
-				builder.addImplicitDependency(pkg.name as string, depName);
+				builder.addImplicitDependency(pkg["name"] as string, depName);
 			});
 		});
 

--- a/packages/cargo/tsconfig.lib.json
+++ b/packages/cargo/tsconfig.lib.json
@@ -4,7 +4,8 @@
 		"module": "commonjs",
 		"outDir": "../../dist/out-tsc",
 		"declaration": true,
-		"types": ["node"]
+		"types": ["node"],
+		"noPropertyAccessFromIndexSignature": true
 	},
 	"exclude": ["**/*.spec.ts", "**/*.test.ts"],
 	"include": ["**/*.ts"]


### PR DESCRIPTION
With this update, all `@nxrs/cargo` executors will correctly handle a `package` key added to the `options`. This can be useful if (for some reason) you want your Nx project name and your Cargo package name to be different.

For example, given the following project configuration:

```toml
# packages/foo/Cargo.toml
[package]
name = "foo-rs"
# ...
```
```toml
# /Cargo.toml
[workspace]
members = ["packages/foo"]
```
```jsonc
// packages/foo/project.json
{
  "root": "packages/foo",
  // ...
  "targets": {
    "test": {
      "executor": "@nxrs/cargo:test",
      "options": {
        "package": "foo-rs"
        // ...
      }
    }
    // ...
  }
}
```

Running `npx nx test foo` should now execute `cargo test -p foo-rs`