### PR TITLE
Fix handling of `release` option

### DIFF
--- a/packages/cargo/src/common/index.spec.ts
+++ b/packages/cargo/src/common/index.spec.ts
@@ -44,6 +44,16 @@ describe("common utils", () => {
 			expect(args.join(" ")).toEqual("cargo build --bin test-app");
 		});
 
+		it("should correctly handle `release` option", () => {
+			let ctx = mockExecutorContext("test-app:build");
+
+			let args = ["cargo", ...parseCargoArgs(Target.Build, { release: false }, ctx)];
+			expect(args.join(" ")).toEqual("cargo build --bin test-app");
+
+			args = ["cargo", ...parseCargoArgs(Target.Build, { release: true }, ctx)];
+			expect(args.join(" ")).toEqual("cargo build --bin test-app --profile release");
+		});
+
 		it("should pass through unknown arguments to cargo", () => {
 			let ctx = mockExecutorContext("test-app:build");
 

--- a/packages/cargo/src/common/index.ts
+++ b/packages/cargo/src/common/index.ts
@@ -189,8 +189,21 @@ export function parseCargoArgs<T extends CargoOptions>(
 	if (opts.target)
 		processArg(args, opts, "target", "--target", opts.target);
 
-	if (opts.release)
-		processArg(args, opts, "release", "--release");
+	if (opts.release != null) {
+		if (opts.release) {
+			args.push("--profile", "release");
+
+			if (opts["profile"]) {
+				let label = chalk.bold.yellowBright.inverse(" WARNING ");
+				console.log(
+					`${label} Conflicting options found: "release" and "profile" `
+						+ `-- "profile" will be overridden`
+				)
+				delete opts["profile"];
+			}
+		}
+		delete opts.release;
+	}
 
 	if (opts.targetDir)
 		processArg(args, opts, "targetDir", "--target-dir", opts.targetDir);

--- a/packages/cargo/src/generators/binary/generator.ts
+++ b/packages/cargo/src/generators/binary/generator.ts
@@ -24,11 +24,11 @@ export default async function (host: Tree, opts: CLIOptions) {
 			build: {
 				executor: "@nxrs/cargo:build",
 				options: {
-					release: false,
+					profile: "dev"
 				},
 				configurations: {
 					production: {
-						release: true,
+						profile: "release"
 					},
 				},
 			},

--- a/packages/cargo/src/generators/library/generator.ts
+++ b/packages/cargo/src/generators/library/generator.ts
@@ -24,11 +24,11 @@ export default async function (host: Tree, opts: CLIOptions) {
 			build: {
 				executor: '@nxrs/cargo:build',
 				options: {
-					release: false,
+					profile: "dev",
 				},
 				configurations: {
 					production: {
-						release: true,
+						profile: "release",
 					},
 				},
 			},


### PR DESCRIPTION
Previously, the generators had been creating project configurations that looked like this:

```jsonc
{
  // ...
  "targets": {
    "build": {
      "executor": "@nxrs/cargo:build",
      "options": {
        "release": false
      },
      "configurations": {
        "production": {
          "release": true
        }
      }
    }
// ...
```
The `release` option was passed straight through to Cargo as a command line argument, but Cargo's `--release` flag is just an alias for `--profile release`, and passing `--release false` would cause Cargo to fail.

This update changes the default generated project configurations to use `--profile dev` by default and `--profile release` for production, and updates the argument parsing logic to handle the `release` option without erroring when it is present.