### PR TITLE
Fix clippy args parsing

### DIFF
--- a/packages/cargo/src/common/index.spec.ts
+++ b/packages/cargo/src/common/index.spec.ts
@@ -1,6 +1,13 @@
 import { ExecutorContext, Tree } from "@nx/devkit";
 import { createTreeWithEmptyWorkspace } from "@nx/devkit/testing";
-import { CargoOptions, normalizeGeneratorOptions, parseCargoArgs, Target } from ".";
+
+import ClippyCliOptions from "../executors/clippy/schema";
+import {
+	CargoOptions,
+	normalizeGeneratorOptions,
+	parseCargoArgs,
+	Target,
+} from "./index";
 
 describe("common utils", () => {
 	describe("parseCargoArgs", () => {
@@ -33,7 +40,9 @@ describe("common utils", () => {
 			expect(args.join(" ")).toEqual("cargo run -p foo");
 
 			args = ["cargo", ...parseCargoArgs(Target.Clippy, opts, ctx)];
-			expect(args.join(" ")).toEqual("cargo clippy -p foo");
+			expect(args.join(" ")).toEqual(
+				"cargo clippy -p foo -- -D warnings --no-deps"
+			);
 		});
 
 		it("should ignore the Nx-config-specified target name", () => {
@@ -84,6 +93,23 @@ describe("common utils", () => {
 
 			expect(args.join(" ")).toEqual(
 				"cargo build -p test-app --bin custom-bin-name",
+			);
+		});
+
+		it("correctly handles pass-through arguments for clippy", () => {
+			let ctx = mockExecutorContext("test-app:lint");
+			let opts: ClippyCliOptions = {
+				package: "test-app-pkg",
+				target: "wasm32-unknown-unknown",
+				fix: false,
+				failOnWarnings: true,
+				noDeps: true,
+			};
+			let args = ["cargo", ...parseCargoArgs(Target.Clippy, opts, ctx)];
+
+			expect(args.join(" ")).toEqual(
+				"cargo clippy -p test-app-pkg --target wasm32-unknown-unknown "
+					+ "-- -D warnings --no-deps",
 			);
 		});
 	});

--- a/packages/cargo/src/executors/clippy/executor.ts
+++ b/packages/cargo/src/executors/clippy/executor.ts
@@ -4,10 +4,8 @@ import CLIOptions from "./schema";
 
 export default async function (opts: CLIOptions, ctx: ExecutorContext) {
 	try {
-		let args = [
-			...parseCargoArgs(Target.Clippy, opts, ctx),
-			...parseClippyArgs(opts),
-		];
+		let args = parseCargoArgs(Target.Clippy, opts, ctx);
+
 		await runCargo(args, ctx);
 
 		return { success: true };
@@ -17,20 +15,4 @@ export default async function (opts: CLIOptions, ctx: ExecutorContext) {
 			reason: err?.message,
 		};
 	}
-}
-
-function parseClippyArgs(opts: CLIOptions): string[] {
-	let args = ["--"];
-
-	if (opts.failOnWarnings || opts.failOnWarnings == null) {
-		args.push("-D", "warnings");
-	}
-	if (opts.noDeps || opts.noDeps == null) {
-		args.push("--no-deps");
-	}
-	if (opts.fix) {
-		args.push("--fix");
-	}
-
-	return args;
 }

--- a/packages/cargo/src/executors/clippy/schema.d.ts
+++ b/packages/cargo/src/executors/clippy/schema.d.ts
@@ -1,6 +1,8 @@
 import {
 	CompilationOptions,
+	DisplayOptions,
 	FeatureSelection,
+	ManifestOptions,
 } from "../../common/schema";
 
 type Options =


### PR DESCRIPTION
Fixes an issue introduced in v0.5.0 causing some `@nxrs/cargo:clippy` options to be passed directly to `cargo`, causing the command to fail.