### PR TITLE
Merge `env` option with `process.env`

### DIFF
--- a/packages/cargo/src/common/index.ts
+++ b/packages/cargo/src/common/index.ts
@@ -148,7 +148,7 @@ export function parseCargoArgs<T extends CargoOptions>(
 	target: Target,
 	options: T,
 	ctx: ExecutorContext,
-): [string[], Record<string, string>?] {
+): [string[], Record<string, string|undefined>?] {
 	let opts = { ...options };
 	let args = [] as string[];
 
@@ -309,9 +309,13 @@ function parseClippyArgs(opts: ClippyCliOptions): string[] {
 	return args;
 }
 
-function extractEnv(opts: CargoOptions): Record<string, string> | undefined {
+function extractEnv(opts: CargoOptions): Record<string, string|undefined> | undefined {
 	if ("env" in opts && opts.env != null) {
-		const env = { ...opts.env };
+		const env = {
+			...process.env,
+			...opts.env,
+		};
+
 		delete opts.env;
 
 		return env;
@@ -328,7 +332,11 @@ function processArg(
 	delete opts[key];
 }
 
-export function runCargo(args: string[], ctx: ExecutorContext, env?: Record<string, string>) {
+export function runCargo(
+	args: string[],
+	ctx: ExecutorContext,
+	env?: Record<string, string|undefined>,
+) {
 	console.log(chalk.dim`> cargo ${
 		args.map(arg => / /.test(arg) ? `"${arg}"` : arg)
 			.join(" ")


### PR DESCRIPTION
This PR updates the handling of the `env` option to only add new or replace existing variables in the environment, rather than outright replacing the entire environment with the options passed in.

This fixes an issue where providing an `env` option could cause builds to fail due to the spawned `cargo` process no longer having access to some `rustc` dependencies that would normally be available on the `PATH`.